### PR TITLE
Add favicons to two pages

### DIFF
--- a/siteDataEmbedded.html
+++ b/siteDataEmbedded.html
@@ -3,6 +3,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/x-icon" href="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/cookie/fill1/24px.svg">
   <script>
   function ready() {
       document.getElementById("domain").innerText = document.domain;

--- a/siteDataTester.html
+++ b/siteDataTester.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/x-icon" href="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/cookie/default/24px.svg">
   <script>
     function failure_(e) {
       console.log("Error: ", e);


### PR DESCRIPTION
Add favicons to two pages so we can test SAA popups with favicons on embedding and requesting origins.